### PR TITLE
Update the command to setup xatu's clickhouse db

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ We strongly recommend using Clickhouse to query the data. Clickhouse is a fast, 
        ```
     2. Start the Xatu clickhouse stack
        ```bash
-       docker compose up -d --profile clickhouse
+       docker compose --profile clickhouse up --detach
        ```
     3. Verify the Clickhouse server is running and migrations are applied
        ```bash


### PR DESCRIPTION
# Description
When trying to setup a local `clickhouse` database following the instructions at the README file, the command: 
```
$docker compose up -d --profile clickhouse
``` 
wasn't working (at least locally with `Docker version 26.1.3`):
```
unknown flag: --profile
```

I checked the [`xatu` repo](https://github.com/ethpandaops/xatu?tab=readme-ov-file#local-clickhouse) and saw that the command wasn't the same one, and the one in `xatu` actually works.   