### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/generate-repo.yml
+++ b/.github/workflows/generate-repo.yml
@@ -12,14 +12,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout local repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Checkout remote repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: "ethpandaops/xatu"
           path: "xatu"
       - name: Setup Docker
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
       - name: Run Docker Compose in remote repo
         run: |
           cd xatu

--- a/.github/workflows/update-availability.yml
+++ b/.github/workflows/update-availability.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.