### PR TITLE
Add beacon_api_eth_v1_events_block_gossip table

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -186,6 +186,26 @@ tables:
     tags:
       - Consensus layer
     description: Contains beacon API eventstream "block" data from each sentry client attached to a beacon node.
+  - name: beacon_api_eth_v1_events_block_gossip
+    database: default
+    excluded_columns: []
+    partitioning:
+      type: datetime
+      column: slot_start_date_time
+      interval: daily
+    networks:
+      mainnet:
+        from: "2025-06-01"
+        to: "2025-07-26"
+      holesky:
+        from: "2025-06-01"
+        to: "2025-07-26"
+      sepolia:
+        from: "2025-06-01"
+        to: "2025-07-26"
+    tags:
+      - Consensus layer
+    description: Contains beacon API eventstream "block_gossip" data from each sentry client attached to a beacon node.
   - name: beacon_api_eth_v1_events_chain_reorg
     database: default
     excluded_columns: []


### PR DESCRIPTION
## Summary
- Add new `beacon_api_eth_v1_events_block_gossip` table configuration
- Set start date to June 1, 2025 for all networks (mainnet, holesky, sepolia)
- Table structure matches existing `beacon_api_eth_v1_events_block` table

## Changes
This PR adds a minimal configuration entry for the new block_gossip events table that will track gossip events from the beacon API event stream.

🤖 Generated with [Claude Code](https://claude.ai/code)