### PR TITLE
ci(generate-repo.yml): pin ClickHouse version to 25.6.3.116

### DIFF
--- a/.github/workflows/generate-repo.yml
+++ b/.github/workflows/generate-repo.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Setup Docker
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - name: Run Docker Compose in remote repo
+        # Until https://github.com/ClickHouse/ClickHouse/issues/86434 is resolved, dont use latest.
+        env:
+          CHVER: 25.6.3.116
         run: |
           cd xatu
           docker compose --profile clickhouse up -d


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/issues/86434